### PR TITLE
Fix that contract seq number not being incremented.

### DIFF
--- a/core/scc/evmscc/evmscc.go
+++ b/core/scc/evmscc/evmscc.go
@@ -94,13 +94,14 @@ func (evmcc *EvmChaincode) Invoke(stub shim.ChaincodeStubInterface) pb.Response 
 
 		var seq uint64
 		if s == binary.Zero256 {
-			logger.Debugf("This is the fisrt contract deployed by %x", callerAddr.Bytes())
 			seq = 0
 		} else {
 			seq = binary.Uint64FromWord256(s)
-			logger.Debugf("This is %d contract deployed by %x", seq+1, callerAddr.Bytes())
-			state.SetStorage(callerAddr, seqKey, binary.Uint64ToWord256(seq+1))
 		}
+
+		// Update contract seq number
+		logger.Debugf("Contract sequence number = %d", seq)
+		state.SetStorage(callerAddr, seqKey, binary.Uint64ToWord256(seq+1))
 
 		contractAddr := account.NewContractAddress(callerAddr, seq)
 		contractAcct := account.ConcreteAccount{Address: contractAddr}.MutableAccount()


### PR DESCRIPTION
Contract seq number was not initialized to zero, therefore remains
zero for subsequent deployment. Therefore, same contract addresses
are generated.

Change-Id: Ie4ba74bcf18e1b2ed98fd028d8f1d03d1334c246
Signed-off-by: Jay Guo <guojiannan1101@gmail.com>

<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #

## How Has This Been Tested?
<!-- If this PR does not contain a new test case, explain why. -->
<!-- Describe in detail how you tested your changes. -->

## Checklist:
<!-- To check a box, and an 'x': [x] -->
<!-- To uncheck box, add a space: [ ] -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [] I have either added documentation to cover my changes or this change requires no new documentation.
- [] I have either added unit tests to cover my changes or this change requires no new tests.
- [] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by:
